### PR TITLE
Use short syntax for functions/objects/classes in PHPDoc

### DIFF
--- a/WPForms/Sniffs/PHP/BackSlashSniff.php
+++ b/WPForms/Sniffs/PHP/BackSlashSniff.php
@@ -23,6 +23,7 @@ class BackSlashSniff extends BaseSniff implements Sniff {
 	public function register() {
 
 		return [
+			T_DOC_COMMENT_STRING,
 			T_STRING,
 		];
 	}
@@ -41,6 +42,27 @@ class BackSlashSniff extends BaseSniff implements Sniff {
 
 		$tokens = $phpcsFile->getTokens();
 
+		if ( $tokens[ $stackPtr ]['code'] === T_DOC_COMMENT_STRING ) {
+			$this->processComments( $phpcsFile, $stackPtr );
+
+			return;
+		}
+
+		$this->processCode( $phpcsFile, $stackPtr );
+	}
+
+	/**
+	 * Process code.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position in the PHP_CodeSniffer file's token stack where the token was found.
+	 */
+	private function processCode( $phpcsFile, $stackPtr ) {
+
+		$tokens = $phpcsFile->getTokens();
+
 		if ( ! in_array( $tokens[ $stackPtr + 1 ]['code'], [ T_OPEN_PARENTHESIS, T_DOUBLE_COLON ], true ) ) {
 			return;
 		}
@@ -50,14 +72,69 @@ class BackSlashSniff extends BaseSniff implements Sniff {
 		}
 
 		if ( $tokens[ $stackPtr - 2 ]['code'] !== T_STRING ) {
-			$phpcsFile->addError(
-				'Remove unnecessary backslash',
-				$stackPtr,
-				'RemoveBackslash'
-			);
+			$this->removeBackslashMessage( $phpcsFile, $stackPtr );
 
 			return;
 		}
+
+		$this->useShortSyntaxMessage( $phpcsFile, $stackPtr );
+	}
+
+	/**
+	 * Process comments.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position in the PHP_CodeSniffer file's token stack where the token was found.
+	 */
+	private function processComments( $phpcsFile, $stackPtr ) {
+
+		$tokens = $phpcsFile->getTokens();
+
+		if ( $tokens[ $stackPtr - 2 ]['code'] !== T_DOC_COMMENT_TAG ) {
+			return;
+		}
+
+		if ( preg_match( '~^[\\\]\w+[\\\]~', $tokens[ $stackPtr ]['content'] ) ) {
+			$this->useShortSyntaxMessage( $phpcsFile, $stackPtr );
+
+			return;
+		}
+
+		if ( preg_match( '~^[\\\]\w+~', $tokens[ $stackPtr ]['content'] ) ) {
+			$this->removeBackslashMessage( $phpcsFile, $stackPtr );
+
+			return;
+		}
+	}
+
+	/**
+	 * Remove backslash message.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position in the PHP_CodeSniffer file's token stack where the token was found.
+	 */
+	private function removeBackslashMessage( $phpcsFile, $stackPtr ) {
+
+		$phpcsFile->addError(
+			'Remove unnecessary backslash',
+			$stackPtr,
+			'RemoveBackslash'
+		);
+	}
+
+	/**
+	 * Use short syntax instead of full function/object/class name.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position in the PHP_CodeSniffer file's token stack where the token was found.
+	 */
+	private function useShortSyntaxMessage( $phpcsFile, $stackPtr ) {
 
 		$phpcsFile->addError(
 			'We prefer imports with `use` statement instead of FQDN',

--- a/WPForms/Tests/TestedFiles/PHP/BackSlash.php
+++ b/WPForms/Tests/TestedFiles/PHP/BackSlash.php
@@ -13,9 +13,32 @@ new DateTime();
 new Example( $a, $b );
 Example2::class;
 
+/**
+ * description that provide some example with code
+ * example:
+ * \DateTime or
+ * \Some\Name\Space\Example( $a, $b ).
+ */
+function test( $type4 ) {}
+
 
 \func( $a, $b, $c );
 \some\name\space\func2( $a, $b, $c );
 new \DateTime( $a, $b );
 new \Some\Name\Space\Example( $a, $b );
 \Some\Name\Space\Example2::class;
+
+
+/**
+ * @param \Some\Name\Space\Type4 $type4
+ *
+ * @return \Some\Name\Space\Type4
+ */
+function test2( $type4 ) {}
+
+/**
+ * @param \DateTime $dateTime Example.
+ *
+ * @return \DateTime
+ */
+function test3( $type4 ) {}

--- a/WPForms/Tests/Tests/PHP/BackSlashTest.php
+++ b/WPForms/Tests/Tests/PHP/BackSlashTest.php
@@ -21,7 +21,7 @@ class BackSlashTest extends TestCase {
 
 		$phpcsFile = $this->process( new BackSlashSniff() );
 
-		$this->fileHasErrors( $phpcsFile, 'RemoveBackslash', [ 17, 19 ] );
-		$this->fileHasErrors( $phpcsFile, 'UseShortSyntax', [ 18, 20, 21 ] );
+		$this->fileHasErrors( $phpcsFile, 'RemoveBackslash', [ 25, 27, 40, 42 ] );
+		$this->fileHasErrors( $phpcsFile, 'UseShortSyntax', [ 26, 28, 29, 33, 35 ] );
 	}
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail. -->
Show notice when in PHPDoc using the full syntax for any tags, but still possible to use long syntax inside the PHPDoc for non-tags description.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (example: Fixes #42.). -->
Fixes #11

## Testing procedure
- [x] I added a test file to WPForms/Tests/TestedFiles/
- [x] I added a unit tests
