### PR TITLE
Language injections sniff

### DIFF
--- a/WPForms/Sniffs/Comments/LanguageInjectionSniff.php
+++ b/WPForms/Sniffs/Comments/LanguageInjectionSniff.php
@@ -43,24 +43,29 @@ class LanguageInjectionSniff extends BaseSniff implements Sniff {
 		$tokens = $phpcsFile->getTokens();
 
 		// Allow `// language=` language injection comment.
-		if ( $tokens[ $stackPtr ]['type'] === 'T_COMMENT' && strpos( $tokens[ $stackPtr ]['content'], '// language=' ) === 0 ) {
+		$currentToken = $tokens[ $stackPtr ];
+
+		if ( $currentToken['type'] === 'T_COMMENT' && strpos( $currentToken['content'], '// language=' ) === 0 ) {
 			// Block 'Inline comments must end in full-stops, exclamation marks, or question marks' error.
-			$phpcsFile->tokenizer->ignoredLines[ $tokens[ $stackPtr ]['line'] ] = [ 'Squiz.Commenting.InlineComment.InvalidEndChar' => true ];
+			$phpcsFile->tokenizer->ignoredLines[ $currentToken['line'] ] = [
+				'Squiz.Commenting.InlineComment.InvalidEndChar' => true,
+				'Squiz.Commenting.InlineComment.SpacingBefore' => true,
+			];
 
 			return;
 		}
 
 		if (
-			isset( $tokens[ $stackPtr ]['comment_closer'] ) === false
+			isset( $currentToken['comment_closer'] ) === false
 			|| (
-				$tokens[ $tokens[ $stackPtr ]['comment_closer'] ]['content'] === ''
-				&& $tokens[ $stackPtr ]['comment_closer'] === ( $phpcsFile->numTokens - 1 )
+				$tokens[ $currentToken['comment_closer'] ]['content'] === ''
+				&& $currentToken['comment_closer'] === ( $phpcsFile->numTokens - 1 )
 			)
 		) {
 			return; // Don't process an unfinished comment during live coding.
 		}
 
-		$commentEnd = $tokens[ $stackPtr ]['comment_closer'];
+		$commentEnd = $currentToken['comment_closer'];
 
 		$empty = [
 			T_DOC_COMMENT_WHITESPACE,

--- a/WPForms/Sniffs/Comments/LanguageInjectionSniff.php
+++ b/WPForms/Sniffs/Comments/LanguageInjectionSniff.php
@@ -45,7 +45,7 @@ class LanguageInjectionSniff extends BaseSniff implements Sniff {
 		// Allow `// language=` language injection comment.
 		$currentToken = $tokens[ $stackPtr ];
 
-		if ( $currentToken['type'] === 'T_COMMENT' && strpos( $currentToken['content'], '// language=' ) === 0 ) {
+		if ( $currentToken['code'] === T_COMMENT && strpos( $currentToken['content'], '// language=' ) === 0 ) {
 			// Block 'Inline comments must end in full-stops, exclamation marks, or question marks' error.
 			$phpcsFile->tokenizer->ignoredLines[ $currentToken['line'] ] = [
 				'Squiz.Commenting.InlineComment.InvalidEndChar' => true,
@@ -56,7 +56,7 @@ class LanguageInjectionSniff extends BaseSniff implements Sniff {
 		}
 
 		if (
-			isset( $currentToken['comment_closer'] ) === false
+			! isset( $currentToken['comment_closer'] )
 			|| (
 				$tokens[ $currentToken['comment_closer'] ]['content'] === ''
 				&& $currentToken['comment_closer'] === ( $phpcsFile->numTokens - 1 )

--- a/WPForms/Sniffs/Comments/LanguageInjectionSniff.php
+++ b/WPForms/Sniffs/Comments/LanguageInjectionSniff.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace WPForms\Sniffs\Comments;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use WPForms\Sniffs\BaseSniff;
+
+/**
+ * Class LanguageInjectionSniff.
+ *
+ * @since 1.0.0
+ */
+class LanguageInjectionSniff extends BaseSniff implements Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array
+	 */
+	public function register() {
+
+		return [
+			T_COMMENT,
+			T_DOC_COMMENT_OPEN_TAG,
+		];
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param int  $stackPtr  The position in the PHP_CodeSniffer file's token stack where the token was found.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+
+		$tokens = $phpcsFile->getTokens();
+
+		// Allow `// language=` language injection comment.
+		if ( $tokens[ $stackPtr ]['type'] === 'T_COMMENT' && strpos( $tokens[ $stackPtr ]['content'], '// language=' ) === 0 ) {
+			// Block 'Inline comments must end in full-stops, exclamation marks, or question marks' error.
+			$phpcsFile->tokenizer->ignoredLines[ $tokens[ $stackPtr ]['line'] ] = [ 'Squiz.Commenting.InlineComment.InvalidEndChar' => true ];
+
+			return;
+		}
+
+		if (
+			isset( $tokens[ $stackPtr ]['comment_closer'] ) === false
+			|| (
+				$tokens[ $tokens[ $stackPtr ]['comment_closer'] ]['content'] === ''
+				&& $tokens[ $stackPtr ]['comment_closer'] === ( $phpcsFile->numTokens - 1 )
+			)
+		) {
+			return; // Don't process an unfinished comment during live coding.
+		}
+
+		$commentEnd = $tokens[ $stackPtr ]['comment_closer'];
+
+		$empty = [
+			T_DOC_COMMENT_WHITESPACE,
+			T_DOC_COMMENT_STAR,
+		];
+
+		$short = $phpcsFile->findNext( $empty, ( $stackPtr + 1 ), $commentEnd, true );
+
+		// Allow `@lang` language injection comment.
+		if ( $short && $tokens[ $short ]['code'] === T_DOC_COMMENT_TAG && $tokens[ $short ]['content'] === '@lang' ) {
+			// Block 'Missing short description in doc comment' error.
+			$phpcsFile->tokenizer->ignoredLines[ $tokens[ $short ]['line'] ] = [ 'Generic.Commenting.DocComment.MissingShort' => true ];
+		}
+	}
+}

--- a/WPForms/Sniffs/Comments/ReturnTagHooks.php
+++ b/WPForms/Sniffs/Comments/ReturnTagHooks.php
@@ -17,7 +17,7 @@ class ReturnTagHooks extends BaseSniff implements Sniff {
 	use CommentTag;
 
 	/**
-	 * List of hook functions that required `@return` type.
+	 * List of hook functions that require `@return` type.
 	 *
 	 * @since 1.0.0
 	 */

--- a/WPForms/Tests/TestCase.php
+++ b/WPForms/Tests/TestCase.php
@@ -47,8 +47,11 @@ class TestCase extends \PHPUnit\Framework\TestCase {
 		$rulesetName = realpath( $this->normalizeFilename( WPFORMS_TESTS_PATH . $rulesetName ) );
 		$config      = new Config( [ '--standard=' . $rulesetName ] );
 		$ruleset     = new Ruleset( $config );
+		$sniffs      = $ruleset->sniffs;
 
 		$ruleset->registerSniffs( [ $classFileName ], [], [] );
+		$ruleset->sniffs = array_merge( $ruleset->sniffs, $sniffs );
+
 		$ruleset->populateTokenListeners();
 
 		$phpcsFile = new LocalFile(

--- a/WPForms/Tests/TestedFiles/Comments/LanguageInjection.php
+++ b/WPForms/Tests/TestedFiles/Comments/LanguageInjection.php
@@ -1,0 +1,11 @@
+<?php
+
+// language=CSS
+$languageInjectionValid = 'body p {font-family: sans-serif}';
+
+//  language=CSS
+$languageInjectionInvalidTwoSpaces = 'body p {font-family: sans-serif}';
+
+$languageInjectionValid = /** @lang HTML */ '<body></body>';
+
+$langInjectionInvalidLong = /** @language HTML */ '<body></body>';

--- a/WPForms/Tests/TestedRulesets/LanguageInjection/ruleset.xml
+++ b/WPForms/Tests/TestedRulesets/LanguageInjection/ruleset.xml
@@ -2,7 +2,7 @@
 <ruleset name="WPForms Tested CS">
 	<description>WPForms Tested CS.</description>
 
-	<config name="installed_paths" value="../../../vendor/wp-coding-standards/wpcs" />
-
-	<rule ref="WordPress" />
+	<rule ref="Squiz.Commenting.InlineComment.InvalidEndChar" />
+	<rule ref="Squiz.Commenting.InlineComment.SpacingBefore" />
+	<rule ref="Generic.Commenting.DocComment.MissingShort" />
 </ruleset>

--- a/WPForms/Tests/TestedRulesets/LanguageInjection/ruleset.xml
+++ b/WPForms/Tests/TestedRulesets/LanguageInjection/ruleset.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset name="WPForms Tested CS">
+	<description>WPForms Tested CS.</description>
+
+	<config name="installed_paths" value="../../../vendor/wp-coding-standards/wpcs" />
+
+	<rule ref="WordPress" />
+</ruleset>

--- a/WPForms/Tests/Tests/Comments/LanguageInjectionTest.php
+++ b/WPForms/Tests/Tests/Comments/LanguageInjectionTest.php
@@ -21,8 +21,8 @@ class LanguageInjectionTest extends TestCase {
 
 		$phpcsFile = $this->process( new LanguageInjectionSniff(), 'LanguageInjection' );
 
-		$this->fileHasErrors( $phpcsFile, 'SpacingBefore', [ 6 ] );
 		$this->fileHasErrors( $phpcsFile, 'InvalidEndChar', [ 6 ] );
+		$this->fileHasErrors( $phpcsFile, 'SpacingBefore', [ 6 ] );
 		$this->fileHasErrors( $phpcsFile, 'MissingShort', [ 11 ] );
 	}
 }

--- a/WPForms/Tests/Tests/Comments/LanguageInjectionTest.php
+++ b/WPForms/Tests/Tests/Comments/LanguageInjectionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace WPForms\Tests\Comments;
+
+use WPForms\Tests\TestCase;
+use WPForms\Sniffs\Comments\LanguageInjectionSniff;
+
+/**
+ * Class LanguageInjectionTest.
+ *
+ * @since 1.0.0
+ */
+class LanguageInjectionTest extends TestCase {
+
+	/**
+	 * Test process.
+	 *
+	 * @since 1.0.0
+	 */
+	public function testProcess() {
+
+		$phpcsFile = $this->process( new LanguageInjectionSniff(), 'LanguageInjection' );
+
+		$this->fileHasErrors( $phpcsFile, 'SpacingBefore', [ 6 ] );
+		$this->fileHasErrors( $phpcsFile, 'InvalidEndChar', [ 6 ] );
+		$this->fileHasErrors( $phpcsFile, 'MissingShort', [ 11 ] );
+	}
+}

--- a/WPForms/Tests/phpunit.xml
+++ b/WPForms/Tests/phpunit.xml
@@ -2,10 +2,13 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="./bootstrap.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd">
+    <filter>
+        <whitelist>
+            <directory suffix=".php">../Sniffs</directory>
+            <directory suffix=".php">../Traits</directory>
+        </whitelist>
+    </filter>
     <testsuites>
         <testsuite name="WPForms-tests">
             <directory suffix=".php">./Tests/</directory>


### PR DESCRIPTION
## Description
Some sniffs are triggered in specific cases that should be excluded. I'll update the list during further testing.

 - PhpStorm's language injection comment `/** @lang <Language> */` triggers Generic.Commenting.DocComment.MissingShort
 - PhpStorm's language injection comment `// language=<Language>` triggers Squiz.Commenting.InlineComment.InvalidEndChar

I have added a new sniff that checks the two language injections mentioned above and blocks the raising relevant errors by another sniff. It required a lot of debugging, however. No examples on the Internet, no such cases in our code.

I have added a simple test for it, which also required a lot of debugging, as we need to use not only the sniff tested but also standard sniffs (in which we have to block raising the error).


## Motivation and Context
Fixes #13.


## Testing procedure
PHPUnit tests.