### PR TITLE
Fix relative path detection in PhpStorm temporary folder.

### DIFF
--- a/WPForms/Sniffs/BaseSniff.php
+++ b/WPForms/Sniffs/BaseSniff.php
@@ -67,7 +67,7 @@ abstract class BaseSniff {
 	}
 
 	/**
-	 * Get project root directory.
+	 * Get relative path from project root directory.
 	 *
 	 * @since 1.0.0
 	 *
@@ -75,10 +75,31 @@ abstract class BaseSniff {
 	 *
 	 * @return string
 	 */
-	protected function getRelatedPath( $phpcsFile ) {
+	protected function getRelativePath( $phpcsFile ) {
 
 		$filePath = realpath( $phpcsFile->path );
 		$root     = $this->getRootDirectory( $phpcsFile );
+
+		$csFolder = 'php_codesniffertemp_folder';
+
+		if ( stripos( $filePath, $csFolder ) !== false ) {
+			// Special case for processing temp file in the PhpStorm temp folder.
+			$filePath = preg_replace( '#.+[/\\\]' . $csFolder . '\d+[/\\\]#i', '', $filePath );
+
+			$rootArr = array_filter( explode( DIRECTORY_SEPARATOR, $root ) );
+
+			$count = count( $rootArr );
+
+			for ( $i = 0; $i < $count; $i++ ) {
+				$rootPart = implode( DIRECTORY_SEPARATOR, array_slice( $rootArr, $i ) );
+
+				if ( strpos( $filePath, $rootPart ) === 0 ) {
+					return str_replace( $rootPart, '', $filePath );
+				}
+			}
+
+			return $filePath;
+		}
 
 		return str_replace( $root, '', $filePath );
 	}

--- a/WPForms/Sniffs/PHP/ValidateDomainSniff.php
+++ b/WPForms/Sniffs/PHP/ValidateDomainSniff.php
@@ -156,7 +156,7 @@ class ValidateDomainSniff extends BaseSniff implements Sniff {
 	 */
 	private function getExpectedDomain( $phpcsFile ) {
 
-		$filePath = $this->getRelatedPath( $phpcsFile );
+		$filePath = $this->getRelativePath( $phpcsFile );
 		$root     = $this->getRootDirectory( $phpcsFile );
 
 		if ( ! empty( $this->domains ) ) {

--- a/WPForms/Sniffs/PHP/ValidateHooksSniff.php
+++ b/WPForms/Sniffs/PHP/ValidateHooksSniff.php
@@ -95,7 +95,7 @@ class ValidateHooksSniff extends BaseSniff implements Sniff {
 			return '';
 		}
 
-		$filePath   = $this->getRelatedPath( $phpcsFile );
+		$filePath   = $this->getRelativePath( $phpcsFile );
 		$hookPieces = array_filter(
 			explode(
 				DIRECTORY_SEPARATOR,

--- a/WPForms/Tests/TestCase.php
+++ b/WPForms/Tests/TestCase.php
@@ -102,7 +102,7 @@ class TestCase extends \PHPUnit\Framework\TestCase {
 	 *
 	 * @return string
 	 */
-	private function normalizeFilename( $filename ) {
+	protected function normalizeFilename( $filename ) {
 
 		return str_replace( '/', DIRECTORY_SEPARATOR, $filename );
 	}

--- a/WPForms/Tests/Tests/BaseSniffTest.php
+++ b/WPForms/Tests/Tests/BaseSniffTest.php
@@ -1,0 +1,120 @@
+<?php
+
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+// phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
+// phpcs:disable WPForms.PHP.UseStatement.UnusedUseStatement
+
+namespace WPForms\Tests;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Ruleset;
+use ReflectionClass;
+use ReflectionException;
+use WPForms\Sniffs\BaseSniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Class BaseSniffTestInstance.
+ *
+ * @since 1.0.0
+ */
+class BaseSniffTestInstance extends BaseSniff {
+
+	/**
+	 * Get relative path from project root directory.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 *
+	 * @return string
+	 */
+	public function getRelativePath( $phpcsFile ) {
+
+		return parent::getRelativePath( $phpcsFile );
+	}
+}
+
+/**
+ * Class BaseSniffTest.
+ *
+ * @since 1.0.0
+ */
+class BaseSniffTest extends TestCase {
+
+	/**
+	 * Test getRelativePath.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @throws ReflectionException ReflectionException.
+	 */
+	public function testGetRelativePath() {
+
+		$className     = BaseSniff::class;
+		$class         = new ReflectionClass( $className );
+		$classFileName = $this->normalizeFilename( $class->getFileName() );
+
+		$rulesetName = '';
+		$rulesetName = $rulesetName ? 'TestedRulesets/' . $rulesetName . '/ruleset.xml' : 'TestedRulesets/Default/ruleset.xml';
+		$rulesetName = realpath( $this->normalizeFilename( WPFORMS_TESTS_PATH . $rulesetName ) );
+		$config      = new Config( [ '--standard=' . $rulesetName ] );
+		$ruleset     = new Ruleset( $config );
+		$phpcsFile   = new File(
+			$classFileName,
+			$ruleset,
+			$config
+		);
+
+		$subject = new BaseSniffTestInstance();
+
+		$relativePath = $subject->getRelativePath( $phpcsFile );
+
+		self::assertSame( $classFileName, WPFORMS_ROOT_PATH . $relativePath );
+
+		$classFileName = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'PHP_CodeSniffertemp_folder0000' . DIRECTORY_SEPARATOR . $relativePath;
+
+		if ( file_exists( $classFileName ) ) {
+			unlink( $classFileName );
+		}
+
+		$this->mkdirRecursive( $classFileName );
+
+		$phpcsFile = new File(
+			$classFileName,
+			$ruleset,
+			$config
+		);
+
+		self::assertSame( $relativePath, $subject->getRelativePath( $phpcsFile ) );
+	}
+
+	/**
+	 * Make directory recursive.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Path.
+	 *
+	 * @return void
+	 */
+	private function mkdirRecursive( $path ) {
+
+		$str = explode( DIRECTORY_SEPARATOR, $path );
+		$dir = '';
+
+		foreach ( $str as $index => $part ) {
+			if ( $index === 0 ) {
+				$dir = $part;
+			} else {
+				$dir .= DIRECTORY_SEPARATOR . $part;
+			}
+
+			if ( $dir !== '' && ! is_dir( $dir ) && strpos( $dir, '.' ) === false ) {
+				mkdir( $dir );
+			} elseif ( ! file_exists( $dir ) && strpos( $dir, '.' ) !== false ) {
+				touch( $dir );
+			}
+		}
+	}
+}

--- a/WPForms/Tests/bootstrap.php
+++ b/WPForms/Tests/bootstrap.php
@@ -4,6 +4,13 @@
  */
 
 /**
+ * Path to project root folder.
+ *
+ * @since 1.0.0
+ */
+define( 'WPFORMS_ROOT_PATH', str_replace( '/', DIRECTORY_SEPARATOR, dirname( dirname( __DIR__ ) ) . '/' ) );
+
+/**
  * Path to tests.
  *
  * @since 1.0.0
@@ -15,7 +22,7 @@ define( 'WPFORMS_TESTS_PATH', str_replace( '/', DIRECTORY_SEPARATOR, __DIR__ . '
  *
  * @since 1.0.0
  */
-define( 'WPFORMS_SNIFFS_PATH', str_replace( '/', DIRECTORY_SEPARATOR, realpath( __DIR__ . '/../Sniffs' ) . '/' ) );
+define( 'WPFORMS_SNIFFS_PATH', str_replace( '/', DIRECTORY_SEPARATOR, dirname( __DIR__ ) . '/Sniffs/' ) );
 
 /**
  * Path to test files.


### PR DESCRIPTION
## Description
We use relative path detection in ValidateDomain and ValidateHooks sniffs. It works well when we run phpcs as a standalone process. However, in PhpStorm the relative path was detected improperly, providing the following distorted messages:

![Screenshot_2](https://user-images.githubusercontent.com/28291450/146070887-91c7d502-d808-486d-99a7-ae6332f72b96.png)

This happed because PhpStorm runs phpcs on a copy of the PHP file, located in the temp folder. The current fix provides processing of this special case.

## Testing procedure
Open any old file having hooks not by the current standard, for instance, `wp-content/plugins/wpforms/includes/class-frontend.php:1416`. Hover on the line 1416:

```
$captcha_inline = apply_filters( 'wpforms_frontend_captcha_inline_script', $this->get_captcha_inline_script( $captcha_settings ) );
```

Make sure that popup message in PhpStorm is: "phpcs: WPForms.PHP.ValidateHooks.InvalidHookName: The wpforms_frontend_captcha_inline_script is invalid hook name. The hook name should start with wpforms_includes_class-frontend."
