### PR TITLE
Remove requirement for a new line before break statement inside the switch.

### DIFF
--- a/WPForms/Sniffs/BaseSniff.php
+++ b/WPForms/Sniffs/BaseSniff.php
@@ -152,6 +152,30 @@ abstract class BaseSniff {
 	}
 
 	/**
+	 * Check whether the token is break in switch statement.
+	 *
+	 * @since 1.0.4
+	 *
+	 * @param File  $phpcsFile The PHP_CodeSniffer file where the token was found.
+	 * @param array $token     First token on the next line.
+	 *
+	 * @return bool
+	 */
+	protected function isBreakInSwitch( $phpcsFile, $token ) {
+
+		$tokens = $phpcsFile->getTokens();
+
+		if ( $token['code'] !== T_BREAK ) {
+			return false;
+		}
+
+		return (
+			isset( $token['scope_condition'] ) &&
+			in_array( $tokens[ $token['scope_condition'] ]['code'], [ T_CASE, T_DEFAULT ], true )
+		);
+	}
+
+	/**
 	 * Get fully qualified class name.
 	 *
 	 * @since 1.0.0

--- a/WPForms/Sniffs/Formatting/EmptyLineAfterAssigmentVariablesSniff.php
+++ b/WPForms/Sniffs/Formatting/EmptyLineAfterAssigmentVariablesSniff.php
@@ -62,7 +62,10 @@ class EmptyLineAfterAssigmentVariablesSniff extends BaseSniff implements Sniff {
 			return;
 		}
 
-		if ( in_array( $nextLineTokens[0]['code'], $this->getAllowedTokensAfterAssigment(), true ) ) {
+		if (
+			$this->isBreakInSwitch( $phpcsFile, $nextLineTokens[0] ) ||
+			in_array( $nextLineTokens[0]['code'], $this->getAllowedTokensAfterAssigment(), true )
+		) {
 			return;
 		}
 

--- a/WPForms/Sniffs/Formatting/SwitchSniff.php
+++ b/WPForms/Sniffs/Formatting/SwitchSniff.php
@@ -52,7 +52,7 @@ class SwitchSniff extends BaseSniff implements Sniff {
 			$this->processCase( $phpcsFile, $stackPtr );
 		}
 
-		if ( $tokens[ $stackPtr ]['code'] === T_BREAK ) {
+		if ( $this->isBreakInSwitch( $phpcsFile, $tokens[ $stackPtr ] ) ) {
 			$this->processBreak( $phpcsFile, $stackPtr );
 		}
 	}
@@ -70,6 +70,10 @@ class SwitchSniff extends BaseSniff implements Sniff {
 		$tokens   = $phpcsFile->getTokens();
 		$previous = $phpcsFile->findPrevious( T_WHITESPACE, $stackPtr - 1, null, true );
 
+		if ( $previous === false ) {
+			return;
+		}
+
 		if ( $tokens[ $stackPtr ]['line'] - $tokens[ $previous ]['line'] === 1 ) {
 			$this->addEmptyLineError( $phpcsFile, $stackPtr );
 		}
@@ -82,7 +86,7 @@ class SwitchSniff extends BaseSniff implements Sniff {
 
 		$next = $phpcsFile->findNext( T_WHITESPACE, $tokens[ $stackPtr ]['scope_closer'] + 1, null, true );
 
-		if ( $tokens[ $next ]['code'] === T_CLOSE_CURLY_BRACKET ) {
+		if ( $next === false || ( $tokens[ $next ]['code'] === T_CLOSE_CURLY_BRACKET ) ) {
 			return;
 		}
 
@@ -156,8 +160,8 @@ class SwitchSniff extends BaseSniff implements Sniff {
 
 		$previousStatement = $phpcsFile->findFirstOnLine( [ T_CASE, T_DEFAULT ], $previous );
 
-		if ( empty( $previousStatement ) && $tokens[ $stackPtr ]['line'] - $tokens[ $previous ]['line'] !== 2 ) {
-			$this->addEmptyLineError( $phpcsFile, $stackPtr );
+		if ( empty( $previousStatement ) && $tokens[ $stackPtr ]['line'] - $tokens[ $previous ]['line'] !== 1 ) {
+			$this->removeEmptyLineError( $phpcsFile, $stackPtr );
 		}
 	}
 

--- a/WPForms/Tests/TestFiles/Formatting/EmptyLineAfterAssigmentVariables.php
+++ b/WPForms/Tests/TestFiles/Formatting/EmptyLineAfterAssigmentVariables.php
@@ -137,3 +137,34 @@ foreach ( $types as $key => $t ) {
 		unset( $types[ $key ] );
 	}
 }
+
+// Good example.
+switch ( $foo ) {
+	case 'foo':
+		$bar = 1;
+		break;
+
+	case 'bar':
+		echo 1;
+		break;
+
+	case 'baz':
+		$bar = 3;
+		break;
+
+	case 'krya':
+	default:
+		$bar = 4;
+		break;
+}
+
+// Good example.
+foreach ( $rays as $ray ) {
+	if ( $ray === 1 ) {
+		$a = 2;
+
+		break;
+	}
+
+	$c = 3;
+}

--- a/WPForms/Tests/TestFiles/Formatting/Switch.php
+++ b/WPForms/Tests/TestFiles/Formatting/Switch.php
@@ -9,13 +9,11 @@ class GoodExample {
 		switch ( $args ) {
 			case 'a':
 				example( $args );
-
 				break;
 
 			case 'b':
 			case 'c':
 				$value = 2;
-
 				break;
 
 			case 'd':
@@ -31,13 +29,11 @@ class GoodExample {
 		switch ( $args ) {
 			case 'a':
 				example( $args );
-
 				break;
 
 			case 'b':
 			case 'c':
 				$value = 2;
-
 				break;
 
 			default:
@@ -65,11 +61,13 @@ class BadExample {
 
 			case 'a':
 				example( $args );
+
 				break;
 			case 'b':
 
 			case 'c':
 				$value = 2;
+
 				break;
 
 			default:
@@ -83,10 +81,12 @@ class BadExample {
 		switch ( $args ) {
 			case 'a':
 				example( $args );
+
 				break;
 			case 'b':
 			case 'c':
 				$value = 2;
+
 				break;
 			default:
 				$value = 3;

--- a/WPForms/Tests/Tests/Formatting/SwitchTest.php
+++ b/WPForms/Tests/Tests/Formatting/SwitchTest.php
@@ -21,7 +21,7 @@ class SwitchTest extends TestCase {
 
 		$phpcsFile = $this->process( new SwitchSniff() );
 
-		$this->fileHasErrors( $phpcsFile, 'AddEmptyLineBefore', [ 64, 68, 69, 73, 86, 87, 90, 91, 94 ] );
-		$this->fileHasErrors( $phpcsFile, 'RemoveEmptyLineBefore', [ 66, 71, 78 ] );
+		$this->fileHasErrors( $phpcsFile, 'AddEmptyLineBefore', [ 60, 66, 86, 91, 94 ] );
+		$this->fileHasErrors( $phpcsFile, 'RemoveEmptyLineBefore', [ 62, 65, 68, 71, 76, 85, 90 ] );
 	}
 }


### PR DESCRIPTION
## Description
Remove requirement for a new line before break statement inside the switch.
Keep requirement for empty line after assignment before the break if foreach.

## Motivation and Context
Fixes #20.

## Testing procedure
- [x] I added a test file to WPForms/Tests/TestFiles/
- [x] I added a unit tests
