### PR TITLE
Fixed hooks name convention

### DIFF
--- a/WPForms/Sniffs/BaseSniff.php
+++ b/WPForms/Sniffs/BaseSniff.php
@@ -248,7 +248,7 @@ abstract class BaseSniff {
 	private function convertClassName( $class ) {
 
 		if ( strpos( $class, '_' ) !== false ) {
-			return $class;
+			return strtolower( $class );
 		}
 
 		return $this->camelToSnake( $class );

--- a/WPForms/Sniffs/BaseSniff.php
+++ b/WPForms/Sniffs/BaseSniff.php
@@ -216,7 +216,18 @@ abstract class BaseSniff {
 		$class = trim( $phpcsFile->getTokensAsString( $classPtr + 1, $classEnd - $classPtr - 1 ) );
 		$class = $this->convertClassName( $class );
 
-		return strtolower( str_replace( '\\', '_', $namespace ? $namespace . '\\' . $class : $class ) );
+		$fqcn = $this->camelToSnake( str_replace( '\\', '', $namespace ) ) . '_' . $class;
+		$fqcn = str_replace(
+			[
+				'wp_forms',
+			],
+			[
+				'wpforms',
+			],
+			$fqcn
+		);
+
+		return $fqcn;
 	}
 
 	/**

--- a/WPForms/Sniffs/BaseSniff.php
+++ b/WPForms/Sniffs/BaseSniff.php
@@ -218,7 +218,22 @@ abstract class BaseSniff {
 
 		$fqcn = $this->camelToSnake( str_replace( '\\', '', $namespace ) ) . '_' . $class;
 
-		return str_replace( 'wp_forms', 'wpforms', $fqcn );
+		$fqcn = str_replace( 'wp_forms', 'wpforms', $fqcn );
+
+		$fqcnArr = explode( '_', $fqcn );
+
+		$prevItem = '';
+
+		// Remove repetitions.
+		foreach ( $fqcnArr as $key => $item ) {
+			if ( $prevItem === $item ) {
+				unset( $fqcnArr[ $key ] );
+			}
+
+			$prevItem = $item;
+		}
+
+		return implode( '_', $fqcnArr );
 	}
 
 	/**

--- a/WPForms/Sniffs/BaseSniff.php
+++ b/WPForms/Sniffs/BaseSniff.php
@@ -217,17 +217,8 @@ abstract class BaseSniff {
 		$class = $this->convertClassName( $class );
 
 		$fqcn = $this->camelToSnake( str_replace( '\\', '', $namespace ) ) . '_' . $class;
-		$fqcn = str_replace(
-			[
-				'wp_forms',
-			],
-			[
-				'wpforms',
-			],
-			$fqcn
-		);
 
-		return $fqcn;
+		return str_replace( 'wp_forms', 'wpforms', $fqcn );
 	}
 
 	/**

--- a/WPForms/Tests/TestFiles/PHP/ValidateHooks.php
+++ b/WPForms/Tests/TestFiles/PHP/ValidateHooks.php
@@ -9,26 +9,26 @@ class ValidateHooks {
 		$extra = 'extra';
 
 		// Valid.
-		apply_filters( 'wpforms_tests_testfiles_php_validate_hooks', true );
-		apply_filters( 'wpforms_tests_testfiles_php_validate_hooks_extra_detail', true );
-		do_action( 'wpforms_tests_testfiles_php_validate_hooks', true );
-		do_action( 'wpforms_tests_testfiles_php_validate_hooks_extra_detail', true );
+		apply_filters( 'wpforms_tests_test_files_php_validate_hooks', true );
+		apply_filters( 'wpforms_tests_test_files_php_validate_hooks_extra_detail', true );
+		do_action( 'wpforms_tests_test_files_php_validate_hooks', true );
+		do_action( 'wpforms_tests_test_files_php_validate_hooks_extra_detail', true );
 
-		apply_filters( "wpforms_tests_testfiles_php_validate_hooks_{$extra}_detail", true );
-		do_action( "wpforms_tests_testfiles_php_validate_hooks_{$extra}_detail" );
+		apply_filters( "wpforms_tests_test_files_php_validate_hooks_{$extra}_detail", true );
+		do_action( "wpforms_tests_test_files_php_validate_hooks_{$extra}_detail" );
 
 		echo apply_filters( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			"wpforms_tests_testfiles_php_validate_hooks_{$extra}_detail",
+			"wpforms_tests_test_files_php_validate_hooks_{$extra}_detail",
 			true
 		);
 
 		// Invalid.
-		apply_filters( 'tests_testfiles_php_validate_hooks', true );
-		apply_filters( 'tests_testfiles_php_validate_hooks_extra_detail', true );
-		do_action( 'tests_testfiles_php_validate_hooks', true );
-		do_action( 'tests_testfiles_php_validate_hooks_extra_detail', true );
+		apply_filters( 'tests_test_files_php_validate_hooks', true );
+		apply_filters( 'tests_test_files_php_validate_hooks_extra_detail', true );
+		do_action( 'tests_test_files_php_validate_hooks', true );
+		do_action( 'tests_test_files_php_validate_hooks_extra_detail', true );
 
-		apply_filters( 'invalid_wpforms_tests_testfiles_php_validate_hooks', true );
-		do_action( 'invalid_wpforms_tests_testfiles_php_validate_hooks', true );
+		apply_filters( 'invalid_wpforms_tests_test_files_php_validate_hooks', true );
+		do_action( 'invalid_wpforms_tests_test_files_php_validate_hooks', true );
 	}
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail. -->
I updated the hook name convention due to [the documentation](https://github.com/awesomemotive/wpforms-plugin/wiki/How-to-name-hooks-(actions-&-filters)).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (example: Fixes #42.). -->


## Testing procedure
- [x] I added a test file to WPForms/Tests/TestFiles/
- [x] I added a unit tests
