### PR TITLE
Domain check for i18n function work isn't correctly for multi domain project

### DIFF
--- a/WPForms/Sniffs/PHP/ValidateDomainSniff.php
+++ b/WPForms/Sniffs/PHP/ValidateDomainSniff.php
@@ -218,13 +218,13 @@ class ValidateDomainSniff extends BaseSniff implements Sniff {
 	 */
 	private function findDomainByProperty( $filePath ) {
 
-		$fileDir       = DIRECTORY_SEPARATOR . ltrim( dirname( $filePath ), DIRECTORY_SEPARATOR );
+		$fileDir       = DIRECTORY_SEPARATOR . trim( dirname( $filePath ), DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR;
 		$currentDomain = '';
 		$currentPath   = '';
 
 		foreach ( $this->domains as $domain => $paths ) {
 			foreach ( $paths as $path ) {
-				$pathDir = $this->normalizePath( $path );
+				$pathDir = DIRECTORY_SEPARATOR . trim( $this->normalizePath( $path ), DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR;
 
 				if (
 					0 === strpos( $fileDir, $pathDir ) &&


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail. -->
I added a directory separator at the end of domains & file dir.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (example: Fixes #42.). -->


## Testing procedure
1. Set up config:
```
<config name="multi_domains" value="true"/>
<rule ref="WPForms.PHP.ValidateDomain">
    <properties>
        <property name="wpforms-lite" value="wpforms"/>
        <property name="wpforms" value="wpforms/pro/,wpforms/src/Pro/"/>
    </properties>
</rule>
```
2. Create a file `wpforms-some-addon-name/some-directory/some-file.php`
3. Add in the file a few i18n functions
4. Run the code sniffer

- [ ] I added a test file to WPForms/Tests/TestFiles/
- [ ] I added a unit tests
