### PR TITLE
Refactor domain validation logic in ValidateDomainSniff

### DIFF
--- a/WPForms/Sniffs/PHP/ValidateDomainSniff.php
+++ b/WPForms/Sniffs/PHP/ValidateDomainSniff.php
@@ -122,6 +122,7 @@ class ValidateDomainSniff extends BaseSniff implements Sniff {
 				$stackPtr,
 				'InvalidDomain'
 			);
+
 			return;
 		}
 

--- a/WPForms/Sniffs/PHP/ValidateDomainSniff.php
+++ b/WPForms/Sniffs/PHP/ValidateDomainSniff.php
@@ -113,7 +113,19 @@ class ValidateDomainSniff extends BaseSniff implements Sniff {
 			return;
 		}
 
-		if ( ! $currentDomain || ! $expectedDomain ) {
+		if ( ! $currentDomain ) {
+			$phpcsFile->addError(
+				sprintf(
+					"Domain name is not set. You should be using '%s'.",
+					$expectedDomain
+				),
+				$stackPtr,
+				'InvalidDomain'
+			);
+			return;
+		}
+
+		if ( ! $expectedDomain ) {
 			return;
 		}
 

--- a/WPForms/Tests/TestFiles/PHP/ValidateDomain.php
+++ b/WPForms/Tests/TestFiles/PHP/ValidateDomain.php
@@ -30,8 +30,8 @@ _ex( 'Invalid', 'Invalid', 'wpforms' );
 _nx( 'Invalid', 'Invalid', 10, 'Invalid', 'wpforms' );
 
 
-// Valid syntax when the text domain is not specified.
-esc_html__( 'Valid' );
+// Invalid syntax when the text domain is not specified.
+esc_html__( 'Invalid' );
 
 // Invalid - not a string as the last argument.
 $bulk_counts['read'] = 25;

--- a/WPForms/Tests/Tests/PHP/ValidateDomainTest.php
+++ b/WPForms/Tests/Tests/PHP/ValidateDomainTest.php
@@ -46,6 +46,6 @@ class ValidateDomainTest extends TestCase {
 
 		$phpcsFile = $this->process( new ValidateDomainSniff(), 'ValidateDomainWithRewrites' );
 
-		$this->fileHasErrors( $phpcsFile, 'InvalidDomain', [ 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 19, 20, 27, 28, 29, 30, 41 ] );
+		$this->fileHasErrors( $phpcsFile, 'InvalidDomain', [ 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 19, 20, 27, 28, 29, 30, 34, 41 ] );
 	}
 }

--- a/WPForms/Tests/Tests/PHP/ValidateDomainTest.php
+++ b/WPForms/Tests/Tests/PHP/ValidateDomainTest.php
@@ -21,7 +21,7 @@ class ValidateDomainTest extends TestCase {
 
 		$phpcsFile = $this->process( new ValidateDomainSniff() );
 
-		$this->fileHasErrors( $phpcsFile, 'InvalidDomain', [ 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 41 ] );
+		$this->fileHasErrors( $phpcsFile, 'InvalidDomain', [ 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 34, 41 ] );
 		$this->fileHasErrors( $phpcsFile, 'NotStringDomain', [ 38 ] );
 	}
 

--- a/WPForms/Tests/Tests/PHP/ValidateDomainTest.php
+++ b/WPForms/Tests/Tests/PHP/ValidateDomainTest.php
@@ -34,7 +34,7 @@ class ValidateDomainTest extends TestCase {
 
 		$phpcsFile = $this->process( new ValidateDomainSniff(), 'MultiDomains' );
 
-		$this->fileHasErrors( $phpcsFile, 'InvalidDomain', [ 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 21, 22, 23, 24, 25, 26 ] );
+		$this->fileHasErrors( $phpcsFile, 'InvalidDomain', [ 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 21, 22, 23, 24, 25, 26, 34 ] );
 	}
 
 	/**


### PR DESCRIPTION
Do not allow current domain name to be empty. Notify the user with an error

Fixes #76 